### PR TITLE
[change_key_server] Change keyserver, because pgp.mit.edu is unreliable.

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,7 +18,7 @@ class yarn::repo (
           repos    => 'main',
           key      => {
             'id'     => '72ECF46A56B4AD39C907BBB71646B01B86E50310',
-            'server' => 'pgp.mit.edu',
+            'server' => 'hkps.pool.sks-keyservers.net',
           },
         }
 


### PR DESCRIPTION
Because of reasons: https://github.com/puppetlabs/puppetlabs-apt/commit/1e1e4b566ed2b7ce7c822365e32b26974afbc756

 :)
