### PR TITLE
Add public key retrieval over https

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -18,6 +18,7 @@ class yarn::repo (
           repos    => 'main',
           key      => {
             'id'     => '72ECF46A56B4AD39C907BBB71646B01B86E50310',
+            'source' => 'https://dl.yarnpkg.com/debian/pubkey.gpg',
           },
         }
 

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -22,7 +22,10 @@ describe 'yarn', type: :class do
               .with_location('http://dl.yarnpkg.com/debian/')
               .with_release('stable')
               .with_repos('main')
-              .with_key('id' => '72ECF46A56B4AD39C907BBB71646B01B86E50310')
+              .with_key(
+                'id' => '72ECF46A56B4AD39C907BBB71646B01B86E50310',
+                'source' => 'https://dl.yarnpkg.com/debian/pubkey.gpg',
+              )
           }
           it { is_expected.not_to contain_yumrepo('yarn') }
         when 'RedHat'


### PR DESCRIPTION
The public key can (now) be retrieved over https.

It's also the recommended way to install the key:
https://yarnpkg.com/en/docs/install#debian-stable