### PR TITLE
use data type instead of legacy validate_*() functions

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,25 +1,16 @@
 # See README.md for usage information
 class yarn (
-  $package_ensure     = $yarn::params::package_ensure,
-  $package_name       = $yarn::params::package_name,
-  $manage_repo        = $yarn::params::manage_repo,
-  $install_method     = $yarn::params::install_method,
-  $source_install_dir = $yarn::params::source_install_dir,
-  $symbolic_link      = $yarn::params::symbolic_link,
-  $user               = $yarn::params::user,
-  $source_url         = $yarn::params::source_url
+  Enum['present','absent'] $package_ensure = $yarn::params::package_ensure,
+  String[1] $package_name = $yarn::params::package_name,
+  Boolean $manage_repo = $yarn::params::manage_repo,
+  Enum['npm', 'source', 'package'] $install_method = $yarn::params::install_method,
+  Stdlib::Absolutepath $source_install_dir = $yarn::params::source_install_dir,
+  Stdlib::Absolutepath $symbolic_link = $yarn::params::symbolic_link,
+  String[1] $user = $yarn::params::user,
+  Stdlib::HTTPUrl $source_url = $yarn::params::source_url
 ) inherits yarn::params {
 
   include stdlib
-
-  validate_string($package_ensure)
-  validate_string($package_name)
-  validate_string($source_install_dir)
-  validate_string($symbolic_link)
-  validate_string($user)
-  validate_string($source_url)
-  validate_bool($manage_repo)
-  validate_re($install_method, [ '^npm$', '^source$', '^package$' ],  'The $install_method only accepts npm, source or package as values')
 
   anchor { 'yarn::begin': }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,12 +1,12 @@
 # See README.md for usage information
 class yarn::install (
-  $package_ensure,
-  $package_name,
-  $install_method,
-  $source_install_dir,
-  $symbolic_link,
-  $user,
-  $source_url,
+  Enum['present','absent'] $package_ensure,
+  String[1] $package_name,
+  Enum['npm', 'source', 'package'] $install_method,
+  Stdlib::Absolutepath $source_install_dir,
+  Stdlib::Absolutepath $symbolic_link,
+  String[1] $user,
+  Stdlib::HTTPUrl $source_url,
 ) {
   assert_private()
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,7 +1,7 @@
 # See README.md for usage information
 class yarn::repo (
-  $manage_repo,
-  $package_name,
+  Boolean $manage_repo,
+  String[1] $package_name,
 ) {
   assert_private()
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -96,16 +96,16 @@ describe 'yarn', type: :class do
         }
       end
 
-      context 'with package_ensure => dummy' do
+      context 'with package_ensure => present' do
         let :params do
           {
-            package_ensure: 'dummy',
+            package_ensure: 'present',
           }
         end
 
         it {
           is_expected.to contain_class('yarn::install')
-            .with_package_ensure('dummy')
+            .with_package_ensure('present')
         }
       end
 
@@ -122,29 +122,29 @@ describe 'yarn', type: :class do
         }
       end
 
-      context 'with source_install_dir => dummy' do
+      context 'with source_install_dir => /yarndir' do
         let :params do
           {
-            source_install_dir: 'dummy',
+            source_install_dir: '/yarndir',
           }
         end
 
         it {
           is_expected.to contain_class('yarn::install')
-            .with_source_install_dir('dummy')
+            .with_source_install_dir('/yarndir')
         }
       end
 
-      context 'with symbolic_link => dummy' do
+      context 'with symbolic_link => /usr/bin/yarn' do
         let :params do
           {
-            symbolic_link: 'dummy',
+            symbolic_link: '/usr/bin/yarn',
           }
         end
 
         it {
           is_expected.to contain_class('yarn::install')
-            .with_symbolic_link('dummy')
+            .with_symbolic_link('/usr/bin/yarn')
         }
       end
 
@@ -161,16 +161,16 @@ describe 'yarn', type: :class do
         }
       end
 
-      context 'with source_url => dummy' do
+      context 'with source_url => https://example.com/yarn.tgz' do
         let :params do
           {
-            source_url: 'dummy',
+            source_url: 'https://example.com/yarn.tgz',
           }
         end
 
         it {
           is_expected.to contain_class('yarn::install')
-            .with_source_url('dummy')
+            .with_source_url('https://example.com/yarn.tgz')
         }
       end
     end


### PR DESCRIPTION
Since Puppet version 4, data types are present and `validate_*()` are deprecated.
This PR is to move from deprecated functions to native datatypes.
The module already have Puppet 4 as lower allowed version.

The module require at least `puppetlabs/stdlib` 5.2.0 that already contains datatype `HTTPUrl` : https://github.com/puppetlabs/puppetlabs-stdlib/commit/b056980ff2e2f907bdda8d75ea99ff01d818d6f9