### PR TITLE
Adjust debian repository key for trixie

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -20,8 +20,8 @@ class yarn::repo (
           release  => 'stable',
           repos    => 'main',
           key      => {
-            'id'     => '72ECF46A56B4AD39C907BBB71646B01B86E50310',
-            'source' => 'https://dl.yarnpkg.com/debian/pubkey.gpg',
+            name   => 'yarn-keyring.gpg',
+            source => 'https://dl.yarnpkg.com/debian/pubkey.gpg',
           },
         }
 

--- a/metadata.json
+++ b/metadata.json
@@ -10,11 +10,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=5.2.0 <9.0.0"
+      "version_requirement": ">=5.2.0 <10.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 7.0.0 <9.0.0"
+      "version_requirement": ">= 7.0.0 <12.0.0"
     },
     {
       "name": "puppetlabs/yumrepo_core",
@@ -62,7 +62,11 @@
       "operatingsystemrelease": [
         "7",
         "8",
-        "9"
+        "9",
+        "10",
+        "11",
+        "12",
+        "13"
       ]
     },
     {


### PR DESCRIPTION
With debian trixie the old `apt-key` method was removed and repository signing keys now reside as own files under `/etc/apt/trusted.gpg.d/` instead of being added to a single big file.

Recent versions of the apt module handle that case correctly if the attribute `name` is given which will be the filename.